### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "ruby app.rb"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Snbank
 ## mini banking system created as a project from the [start.ng](https://www.start.ng) Internship program
-## Start the program by running the app.rb file in your terminal. if you don't have ruby installed, you can use the live version on repl.it [HERE](https://repl.it/@SamuelNwoko/snbank-system).
+## Start the program by running the app.rb file in your terminal. if you don't have ruby installed, you can use the live version on repl.it [![Run on Repl.it](https://repl.it/badge/github/Sahmie/snbank)](https://repl.it/github/Sahmie/snbank)(https://repl.it/@SamuelNwoko/snbank-system).
 ## When the app starts, you'll be prompted to either login as a staff or close the app
 ## If you select Staff login, there are 2 staff login details in a file on the repo named "staff.txt"
 ## login with either of the details and follow through with the instructions


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).